### PR TITLE
Break out license to its own file + Make toc visible

### DIFF
--- a/docs/_static/styles.css
+++ b/docs/_static/styles.css
@@ -176,6 +176,8 @@ li.toctree-4 > a {
 
   .wy-nav-side {
     position: absolute;
+    overflow-x: visible;
+    overflow-y: visible;
   }
 
   .wy-side-scroll {


### PR DESCRIPTION
1. Added license.md so we can move license to the end of the TOC. 

2. When content was less than toc, the toc got cut off. This makes it visible regardless of content.

![Screen Shot 2019-04-18 at 10 23 24 AM](https://user-images.githubusercontent.com/15315514/56367816-18dafd80-61c4-11e9-84d3-eefd9d2bfee7.png)

