### PR TITLE
Separated out license + fixed toc

### DIFF
--- a/docs/_static/styles.css
+++ b/docs/_static/styles.css
@@ -176,6 +176,8 @@ li.toctree-4 > a {
 
   .wy-nav-side {
     position: absolute;
+    overflow-x: visible;
+    overflow-y: visible;
   }
 
   .wy-side-scroll {

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ refine.bio is _not_ a substitute for experiments and processing pipelines tailor
 * [refine.bio Data Processing](main_text.md)
 * [Getting Started](getting_started.md)
 * [FAQ](faq.md)
-
+* [License](license.md)
 ## Questions/Feedback?
 
 If you have a question or comment, please <a href ="https://github.com/AlexsLemonade/refinebio/issues" target = "blank">file an issue on GitHub </a> or send us an email at [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org).

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,3 @@
+# License
+
+This documentation is released under a <a href = "https://github.com/AlexsLemonade/refinebio-docs/blob/master/LICENSE.md" target = "blank">Creative Commons Attribution (CC-BY) license</a>.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -417,9 +417,4 @@ Our <a href = "https://github.com/AlexsLemonade/refinebio-examples" target = "bl
 * Differential expression analysis [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/master/differential-expression" target = "blank">README</a>, <a href = "https://alexslemonade.github.io/refinebio-examples/differential-expression/gene_DE.nb.html" target = "blank">notebook</a>]
 * Converting between different gene identifiers [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/master/ensembl-id-convert" target = "blank">README</a>, <a href = "https://alexslemonade.github.io/refinebio-examples/ensembl-id-convert/ensembl_id_convert.nb.html" target = "blank">notebook</a>]
 * Ortholog mapping [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/master/ortholog-mapping" target = "blank">README</a>, <a href = "https://alexslemonade.github.io/refinebio-examples/ortholog-mapping/ortholog_mapping_example.nb.html" target = "blank">notebook</a>]
-* Clustering/heatmap generation [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/master/clustering" target = "blank">README</a>, <a href = "https://alexslemonade.github.io/refinebio-examples/clustering/clustering_example.nb.html" target = "blank">notebook</a>]
-
-
-# License
-
-This documentation is released under a <a href = "https://github.com/AlexsLemonade/refinebio-docs/blob/master/LICENSE.md" target = "blank">Creative Commons Attribution (CC-BY) license</a>.  
+* Clustering/heatmap generation [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/master/clustering" target = "blank">README</a>, <a href = "https://alexslemonade.github.io/refinebio-examples/clustering/clustering_example.nb.html" target = "blank">notebook</a>] 


### PR DESCRIPTION
1. Added license.md so we can move license to the end of the TOC. 

2. When content was less than toc, the toc got cut off. This makes it visible regardless of content.

![Screen Shot 2019-04-18 at 10 23 24 AM](https://user-images.githubusercontent.com/15315514/56367816-18dafd80-61c4-11e9-84d3-eefd9d2bfee7.png)
