### PR TITLE
Add documentation around skipping QN for individual RNA-seq 

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,3 +69,9 @@ It may be sufficient to include batch, dataset, or platform as covariates for ce
 The `Regenerate Files` button triggers the creation of a new dataset using the same options and including the same samples as the original, expired dataset.
 If there are any changes to the way we process or aggregate datasets (e.g., [target quantiles are updated](http://docs.refine.bio/en/latest/main_text.html#quantile-normalization)) between the initial dataset creation and regeneration, these will be reflected in the new, regenerated dataset and may result in different values.
 Users should take this into account when managing datasets obtained from refine.bio and take steps to appropriately archive datasets they use for analysis.
+
+#### What does it mean to skip quantile normalization for RNA-seq samples?
+
+If you would like to perform differential gene expression analysis with RNA-seq data obtained from refine.bio, you may want to choose to skip quantile normalization, as many methods designed for this problem expect unnormalized counts.
+refine.bio will not provide unnormalized counts when you skip quantile normalization, but it will provide output that can be used for testing differential gene expression (see [Skipping quantile normalization for RNA-seq experiments](http://docs.refine.bio/en/latest/main_text.html#skipping-quantile-normalization-for-rna-seq-experiments) for links to the relevant vignette).
+Note that skipping this step will make a dataset less comparable to other data obtained from refine.bio, as quantile normalization ensures that each sample's underlying distribution is the same (see [Quantile normalizing samples for delivery](http://docs.refine.bio/en/latest/main_text.html#quantile-normalizing-samples-for-delivery)).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,6 +21,8 @@ There will be as many folders as there are selected experiments.
 
 * The `aggregated_metadata.json` file contains information about the options you selected for download.
 Specifically, the `aggregate_by` and `scale_by` fields note how the samples are grouped into gene expression matrices and how the gene expression data values were transformed, respectively.
+The `quantile_normalized` fields notes whether or not quantile normalization was performed.
+Currently, we only support skipping quantile normalization for RNA-seq experiments when aggregating by experiment on the web interface.
 
 * Individual gene expression matrices and their corresponding sample metadata files are in their own directories.
 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -387,6 +387,12 @@ As described above, harmonized values are noted with a `refinebio_` prefix.
 Experiment metadata (e.g., experiment description and title) is delivered in the `metadata_<species>.json` and `aggregated_metadata.json` files.
 
 
+The `aggregated_metadata.json` file contains additional information regarding the processing of your dataset.
+Specifically, the `aggregate_by` and `scale_by` fields note how the samples are grouped into gene expression matrices and how the gene expression data values were transformed, respectively.
+The `quantile_normalized` fields notes whether or not quantile normalization was performed.
+Currently, we only support skipping quantile normalization for RNA-seq experiments when aggregating by experiment on the web interface. 
+
+
 # Species compendia
 
 We periodically release compendia comprised of all the samples from a species that we were able to process.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -303,7 +303,7 @@ Users who seek to analyze RNA-seq and microarray data together should be aware t
 
 #### Skipping quantile normalization for RNA-seq experiments
 
-When selecting RNA-seq samples for download and to aggregate by experiment, users have the option to skip quantile normalization.
+When selecting RNA-seq samples for download and to aggregate by experiment, users have the option to skip quantile normalization by first selecting Advanced Options and checking the "Skip quantile normalization for RNA-seq samples" box.
 In this case, the output of tximport will be delivered in TSV files (see [our section on RNA-seq data processing with tximport](#tximport)). 
 These data can be used for differential expression analysis as "bias corrected counts without an offset" as described in the <a href = "https://bioconductor.org/packages/release/bioc/vignettes/tximport/inst/doc/tximport.html#use-with-downstream-bioconductor-dge-packages" target = "blank">_Use with downstream Bioconductor DGE packages_ section of tximport vignette</a>. 
 Note that these data will be less comparable to other datasets from refine.bio because this step has been skipped.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -301,6 +301,13 @@ This arises in data processed by refine.bio when RNA-seq and microarray data are
 To confirm that we have quantile normalized data correctly before returning results to the user, we evaluate the top half of expression values and confirm that a KS test produces a non-significant p-value.
 Users who seek to analyze RNA-seq and microarray data together should be aware that the low-expressing genes may not be comparable across the sets.
 
+#### Skipping quantile normalization for RNA-seq experiments
+
+When selecting RNA-seq samples for download and to aggregate by experiment, users have the option to skip quantile normalization.
+In this case, the output of tximport will be delivered in TSV files (see [our section on RNA-seq data processing with tximport](#tximport)). 
+These data can be used for differential expression analysis as "bias corrected counts without an offset" as described in the <a href = "https://bioconductor.org/packages/release/bioc/vignettes/tximport/inst/doc/tximport.html#use-with-downstream-bioconductor-dge-packages" target = "blank">_Use with downstream Bioconductor DGE packages_ section of tximport vignette</a>. 
+Note that these data will be less comparable to other datasets from refine.bio because this step has been skipped.
+
 ### Gene transformations
 
 In some cases, it may be useful to row-normalize or transform the gene expression values in a matrix (e.g., following aggregation and quantile normalization).


### PR DESCRIPTION
Closes #95, related to https://github.com/AlexsLemonade/refinebio/pull/1323

- [x] Update the downloadable files section. Specifically, we should mention the `aggregate_by`, `scale_by` and whatever we end up using for this in any discussion of `aggregated_metadata.json`
- [x] Update the Contents section of "Getting Started with a refine.bio dataset"
- [x] Update Processing Information > Transformations > Quantile Normalization section to reflect when it is optional
- [x] Add an FAQ about this - this is where the tool tip ? will link to

At this point, I would like to get feedback from @dvenprasad. It is possible that the section about skipping quantile normalization is sufficient and we don't need to add an FAQ about this matter. If we decide we need an FAQ, it will get added to this branch.
