### PR TITLE
setting a version number - what should it be?

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ author = u'The Childhood Cancer Data Lab'
 # The short X.Y version
 version = u''
 # The full version, including alpha/beta/rc tags
-release = u'0.1.0'
+release = u'1.0.0'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Our current version number, which shows up at the top, is 0.1.0. This is probably wrong. Here I set one (1.0.0) just so we can discuss how we are setting this and what it should be.