### PR TITLE
match transcriptome indices api endpoint

### DIFF
--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -163,17 +163,17 @@ The refine.bio processed Salmon indices are available for download.
 You can make use of our API like so:
 
 ```
-https://api.refine.bio/transcriptome_indices/?organism=<ORGANISM>&length=<LENGTH>
+https://api.refine.bio/transcriptome_indices/?organism_name=<ORGANISM>&length=<LENGTH>
 ```
 Where `<ORGANISM>` is the scientific name of the species in all caps separated by underscores and `<LENGTH>` is either `SHORT` or `LONG`.
 
 To obtain the zebrafish (_Danio rerio_) index used for >75bp reads, use:
 
 ```
-https://api.refine.bio/transcriptome_indices/?organism=DANIO_RERIO&length=LONG
+https://api.refine.bio/transcriptome_indices/?organism_name=DANIO_RERIO&length=LONG
 ```
 
-The `s3_url` field will allow you to download the index.
+The `download_url` field will allow you to download the index.
 
 ##### Quantification with Salmon
 


### PR DESCRIPTION
This PR updates the transcriptome indices endpoint example to reflect the changes in https://github.com/AlexsLemonade/refinebio/pull/2012

`organism` -> `organism_name` for consistency with other endpoints on the api 
`s3_url` -> `download_url` to match other downloadable file uri's on the api

:)