### PR TITLE
add versioned url

### DIFF
--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -163,14 +163,14 @@ The refine.bio processed Salmon indices are available for download.
 You can make use of our API like so:
 
 ```
-https://api.refine.bio/transcriptome_indices/?organism_name=<ORGANISM>&length=<LENGTH>
+https://api.refine.bio/v1/transcriptome_indices/?organism_name=<ORGANISM>&length=<LENGTH>
 ```
 Where `<ORGANISM>` is the scientific name of the species in all caps separated by underscores and `<LENGTH>` is either `SHORT` or `LONG`.
 
 To obtain the zebrafish (_Danio rerio_) index used for >75bp reads, use:
 
 ```
-https://api.refine.bio/transcriptome_indices/?organism_name=DANIO_RERIO&length=LONG
+https://api.refine.bio/v1/transcriptome_indices/?organism_name=DANIO_RERIO&length=LONG
 ```
 
 The `download_url` field will allow you to download the index.


### PR DESCRIPTION
The URL in the documentation now returns an error because it was not versioned. This adds v1.