### PR TITLE
Show refinebio version on docs

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -35,5 +35,16 @@
       }, true)
     })();
   </script>
+
+  <script>
+    fetch('https://api.refine.bio/v1/transcriptome_indices/?limit=1')
+      .then(function(response) {
+        const version = response.headers.get('x-source-revision');
+        const versionElements = document.getElementsByClassName('version');
+        if (versionElements && version) {
+          versionElements[0].textContent = version;
+        }
+      })
+  </script>
 {% endblock %}
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,7 +1,7 @@
 {%- extends "sphinx_rtd_theme/layout.html" %} {% block extrahead %}
 
 <!-- Hotjar Tracking Code for refine.bio -->
-<script>
+<script type="text/javascript">
   (function(h, o, t, j, a, r) {
     h.hj =
       h.hj ||
@@ -36,7 +36,7 @@
     })();
   </script>
 
-  <script>
+  <script type="text/javascript">
     fetch('https://api.refine.bio/v1/transcriptome_indices/?limit=1')
       .then(function(response) {
         const version = response.headers.get('x-source-revision');


### PR DESCRIPTION
This adds code to fetch the latest version from the API and display it. This will be executed every time someone visits the docs page.

Needs https://github.com/AlexsLemonade/refinebio/pull/2122 to be merged first.