### PR TITLE
Rewrite downstream analysis section to reflect new examples

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -74,7 +74,7 @@ with open('aggregated_metadata.json', 'r') as jsonfile:
 print(data)
 ```
 
-For example R workflows, such as clustering of gene expression data, please see https://github.com/AlexsLemonade/refinebio-examples/tree/v1.0.
+For example R workflows, such as clustering of gene expression data, please see [the Getting Started section of refine.bio examples](https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html).
 
 If you identify issues with your download, please [file an issue on GitHub](https://github.com/AlexsLemonade/refinebio/issues). If you would prefer to report issues via e-mail, you can also email [requests@ccdatalab.org](mailto:requests@ccdatalab.org).
 
@@ -167,7 +167,5 @@ with open('aggregated_metadata.json', 'r') as jsonfile:
     data = json.load(jsonfile)
 print(data)
 ```
-
-For example R workflows, such as clustering of gene expression data, please see https://github.com/AlexsLemonade/refinebio-examples/tree/v1.0.
 
 If you identify issues with your download, please [file an issue on GitHub](https://github.com/AlexsLemonade/refinebio/issues). If you would prefer to report issues via e-mail, you can also email [requests@ccdatalab.org](mailto:requests@ccdatalab.org).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,10 @@ refine.bio is a multi-organism collection of genome-wide transcriptome or gene e
 refine.bio allows biologists, clinicians, and machine learning researchers to search for experiments from different source repositories all in one place and build custom data sets for their questions of interest.
 
 refine.bio is well-suited for quickly assessing if signals are present in particular datasets, for identifying and obtaining data sets for accelerated validation of findings, and for building large compendia for training machine learning models that can adequately handle the technical noise associated with integrating multiple experiments and platforms.
-For examples of how to use refine.bio data, please see our [use cases for downstream analysis](https://refinebio-docs.readthedocs.io/en/latest/main_text.html#use-cases-for-downstream-analysis).
+
 refine.bio is _not_ a substitute for experiments and processing pipelines tailored to answer _specific_ biological questions of interest or for input from relevant experts (e.g., those with statistics expertise), but rather a repository of samples processed with standardized pipelines that have been selected based on their wide-ranging utility.
+
+**For examples of how to use refine.bio data, please see [_Downstream Analysis with refine.bio Examples_](https://refinebio-docs.readthedocs.io/en/latest/main_text.html#downstream-analysis-with-refinebio-examples).**
 
 ### Frequently asked questions
 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -548,6 +548,7 @@ View our <a href = "https://alexslemonade.github.io/refinebio-examples/01-gettin
 Here's a sneak peek of examples that are available:
 
 * <a href = "https://alexslemonade.github.io/refinebio-examples/02-microarray/differential-expression_microarray_02_several-groups.html" target = "blank">Differential gene expression analysis for several groups (Microarray)</a>
+* <a href = "https://alexslemonade.github.io/refinebio-examples/03-rnaseq/differential-expression_rnaseq_01.html#analysis" target = "blank">Differential gene expression analysis for 2 groups (RNA-seq)</a>
 * <a href = "https://alexslemonade.github.io/refinebio-examples/03-rnaseq/clustering_rnaseq_01_heatmap.html" target = "blank">Hierarchical clustering and heatmap creation (RNA-seq)</a>
 * <a href = "https://alexslemonade.github.io/refinebio-examples/02-microarray/pathway-analysis_microarray_02_gsea.html" target = "blank">Gene Set Enrichment Analysis (Microarray)</a>
 * <a href = "https://alexslemonade.github.io/refinebio-examples/03-rnaseq/dimension-reduction_rnaseq_02_umap.html" target = "blank">Visualization with Uniform Manifold Approximation and Projection (RNA-seq)</a>

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -376,7 +376,7 @@ Gene expression matrices are delived in <a href = "https://en.wikipedia.org/wiki
 In these matrices, rows are _genes_ or _features_ and columns are _samples_.
 Note that this format is consistent with the input expected by many programs specifically designed for working with gene expression matrices, but some machine learning libraries will expect this to be transposed.
 The column names or header will contain values corresponding to sample accessions (denoted `refinebio_accession_code` in metadata files).
-You can use these values in the header to map between a sample's gene expression data and its metadata (e.g., disease label or age). See also [Use Cases for Downstream Analysis](#use-cases-for-downstream-analysis).
+You can use these values in the header to map between a sample's gene expression data and its metadata (e.g., disease label or age). See also [Downstream Analysis with refine.bio Examples](#downstream-analysis-with-refinebio-examples).
 
 ## Sample Metadata
 
@@ -534,15 +534,24 @@ Below is the detailed folder structure:
 
 You can use the refine.bio API to build your own applications utilizing the refine.bio processed data.
 You can also select samples for aggregation and download via the API with additional options for download (e.g., without quantile normalization, selecting sample-specific `quant.sf` files).
-Our quantile normalization targets and transcriptome indices are available only via the API (see [_Quantile normalizing your own data with refine.bio reference distribution_](#quantile-normalizing-your-own-data-with-refine.bio-reference-distribution) and [_Transcriptome index_](#transcriptome-index), respectively).
+Our quantile normalization targets and transcriptome indices are available only via the API (see [_Quantile normalizing your own data with refine.bio reference distribution_](#quantile-normalizing-your-own-data-with-refinebio-reference-distribution) and [_Transcriptome index_](#transcriptome-index), respectively).
 
 **For more information see our API documentation at <a href = "https://api.refine.bio/" target = "blank">api.refine.bio</a>.**
 
-# Use Cases for Downstream Analysis
+# Downstream Analysis with refine.bio Examples
 
-Our <a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/v1.0" target = "blank">`refinebio-examples`</a> repo includes a number of different analyses you can perform with data from refine.bio. We include examples in the R programming language, and where applicable, <a href = "http://genepattern-notebook.org/example-notebooks/" target = "blank">GenePattern Notebooks</a> and scripts to prepare refine.bio data for use with GenePattern. The following examples are included:
+Our <a href = "https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html" target = "blank">refine.bio examples site</a> includes a number of different analyses you can perform with data from refine.bio in the R programming language. 
+You can view our examples in your browser or download the <a href = "https://rmarkdown.rstudio.com/" target = "blank">R Markdown (`.Rmd`)</a> files to run the code locally (find more information on required software <a href = "https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#03_What_you_need_to_install_to_run_the_examples" target = "blank">here</a> and how to use `.Rmd` <a href = "https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html#05_How_to_use_R_Markdown_Documents" target = "blank">here</a>).
+Example analyses are designed to guide you through obtaining data from the refine.bio web interface and provide instruction for adapting the analysis for a dataset of your choice.
+View our <a href = "https://alexslemonade.github.io/refinebio-examples/01-getting-started/getting-started.html" target = "blank">Getting Started page</a>, <a href = "https://alexslemonade.github.io/refinebio-examples/02-microarray/00-intro-to-microarray.html" target = "blank">Introduction to Microarray</a>, or <a href = "https://alexslemonade.github.io/refinebio-examples/03-rnaseq/00-intro-to-rnaseq.html" target = "blank">Introduction to RNA-seq</a> to start using refine.bio examples.
 
-* Differential expression analysis [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/v1.0/differential-expression" target = "blank">README</a>, <a href = "https://htmlpreview.github.io/?https://github.com/AlexsLemonade/refinebio-examples/blob/v1.0/differential-expression/microarray_DGE.nb.html" target = "blank">microarray notebook</a>, <a href = "https://htmlpreview.github.io/?https://github.com/AlexsLemonade/refinebio-examples/blob/v1.0/differential-expression/rnaseq_DGE.nb.html" target = "blank">RNA-seq notebook</a>]
-* Converting between different gene identifiers [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/v1.0/ensembl-id-convert" target = "blank">README</a>, <a href = "https://htmlpreview.github.io/?https://github.com/AlexsLemonade/refinebio-examples/blob/v1.0/ensembl-id-convert/ensembl_id_convert.nb.html" target = "blank">notebook</a>]
-* Ortholog mapping [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/v1.0/ortholog-mapping" target = "blank">README</a>, <a href = "https://htmlpreview.github.io/?https://github.com/AlexsLemonade/refinebio-examples/blob/v1.0/ortholog-mapping/ortholog_mapping_example.nb.html" target = "blank">notebook</a>]
-* Clustering/heatmap generation [<a href = "https://github.com/AlexsLemonade/refinebio-examples/tree/v1.0/clustering" target = "blank">README</a>, <a href = "https://htmlpreview.github.io/?https://github.com/AlexsLemonade/refinebio-examples/blob/v1.0/clustering/clustering_example.nb.html" target = "blank">notebook</a>]
+Here's a sneak peek of examples that are available:
+
+* <a href = "https://alexslemonade.github.io/refinebio-examples/02-microarray/differential-expression_microarray_02_several-groups.html" target = "blank">Differential gene expression analysis for several groups (microarray)</a>
+* <a href = "https://alexslemonade.github.io/refinebio-examples/03-rnaseq/clustering_rnaseq_01_heatmap.html" target = "blank">Hierarchical clustering and heatmap creation (RNA-seq)</a>
+* <a href = "https://alexslemonade.github.io/refinebio-examples/02-microarray/pathway-analysis_microarray_02_gsea.html" target = "blank">Gene Set Enrichment Analysis (Microarray)</a>
+* <a href = "https://alexslemonade.github.io/refinebio-examples/03-rnaseq/dimension-reduction_rnaseq_02_umap.html" target = "blank">Visualization with Uniform Manifold Approximation and Projection (RNA-seq)</a>
+
+<a href = "https://share.hsforms.com/1pQ8pPB70TuG37sVjr-KtXA336z0" target = "blank">Give us feedback on our refine.bio examples!</a>
+If you have a question about or find a problem with one of our examples and need to get in touch with one of our staff, please <a href = "https://github.com/AlexsLemonade/refinebio-examples/issues/new?assignees=&labels=user+report+or+question&template=report-a-problem-or-ask-a-question.md&title=User+issue%3A++" target = "blank">file a GitHub issue</a>.
+If you would prefer to report issues via e-mail, you can also email [requests@ccdatalab.org](mailto:requests@ccdatalab.org).

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -265,6 +265,7 @@ refine.bio is designed to allow for the aggregation of multiple platforms and ev
 With that in mind, we would like the distributions of samples from different platforms/technologies to be as similar as possible.
 We use <a href ="https://en.wikipedia.org/wiki/Quantile_normalization" target = "blank"> quantile normalization</a> to accomplish this.
 Specifically, we generate a reference distribution for each organism from a large body of data with the `normalize.quantiles.determine.target` function from the <a href = "http://www.bioconductor.org/packages/release/bioc/html/preprocessCore.html" target ="blank">preprocessCore</a> R package and quantile normalize samples that a user selects for download with this target (using the `normalize.quantiles.use.target` function of `preprocessCore`).
+There is a single reference distribution per species, used to normalize all samples from that species regardless of platform or technology.
 We go into more detail below.
 
 #### Reference distribution
@@ -312,8 +313,9 @@ Note that only gene expression matrices that we are able to successfully quantil
 #### Limitations of quantile normalization across platforms with many zeroes
 
 Quantile normalization is a strategy that can address many technical effects, generally at the cost of retaining certain sources of biological variability.
-However, in cases where there are many ties that are different between samples, the transformation can produce outputs with different distributions.
-This arises in data processed by refine.bio when RNA-seq and microarray data are combined.
+We use a single reference distribution per organism, generated from the Affymetrix microarray platform with the largest number of samples we were able to process from raw data (see [_Reference distribution_](#reference=distribution)).
+In cases where the unnormalized data contains many ties within samples (and the ties are different between samples) the transformation can produce outputs with somewhat different distributions.
+This situation arises most often when RNA-seq data and microarray data are combined into a single dataset or matrix.
 To confirm that we have quantile normalized data correctly before returning results to the user, we evaluate the top half of expression values and confirm that a KS test produces a non-significant p-value.
 Users who seek to analyze RNA-seq and microarray data together should be aware that the low-expressing genes may not be comparable across the sets.
 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -426,6 +426,7 @@ We offer two kinds of refine.bio compendia: [normalized compendia](#normalized-c
 refine.bio normalized compendia are comprised of all the samples from a species that we were able to process, aggregate, and normalize.
 Normalized compendia provide a snapshot of the most complete collection of gene expression that refine.bio can produce for each supported organism.
 We process these compendia in a manner that is different from the options that are available via the web user interface.
+Note that [submitter processed](#submitter-processed--) samples that are available through the web user interface are omitted from normalized compendia because [these samples can introduce unwanted technical variation](https://github.com/AlexsLemonade/refinebio/issues/2114).
 
 The refine.bio web interface does an inner join when datasets are combined, so only genes present in all datasets are included in the final matrix.
 For compendia, we take the union of all genes, filling in any missing values with `NA`.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -534,7 +534,7 @@ Below is the detailed folder structure:
 
 You can use the refine.bio API to build your own applications utilizing the refine.bio processed data.
 You can also select samples for aggregation and download via the API with additional options for download (e.g., without quantile normalization, selecting sample-specific `quant.sf` files).
-Our quantile normalization targets and transcriptome indices are available only via the API (see [_Quantile normalizing your own data with refine.bio reference distribution_](#quantile-normalizing-your-own-data-with-refinebio-reference-distribution) and [_Transcriptome index_](#transcriptome-index), respectively).
+Our quantile normalization targets and transcriptome indices are available only via the API (see [_Quantile normalizing your own data with refine.bio reference distribution_](#quantile-normalizing-your-own-data-with-refine-bio-reference-distribution) and [_Transcriptome index_](#transcriptome-index), respectively).
 
 **For more information see our API documentation at <a href = "https://api.refine.bio/" target = "blank">api.refine.bio</a>.**
 


### PR DESCRIPTION
⚠️  _also includes changes from #145_

Closes #138. When we get a home page for refine.bio examples, this will probably need another go! We also may want this section to more closely mirror what is on the refine.bio homepage when it gets restructured (https://github.com/AlexsLemonade/refinebio-frontend/issues/926). 

Did I miss any instances of "Use Cases for Downstream Analysis" and the link to the proper header? The link in getting started won't work until this is live.
