### PR TITLE
Handle Missing Assets

### DIFF
--- a/docs/_static/styles.css
+++ b/docs/_static/styles.css
@@ -51,22 +51,12 @@ p {
   position: relative;
 }
 
-.icon-home {
-  width: 154px;
-  height: 59px;
-  padding: 32px;
-  background-repeat: no-repeat;
-  filter: brightness(0) invert(1);
-  color: transparent !important;
-  margin-top: 32px;
-}
-
 .wy-side-nav-search a:not(.wy-side-nav-search__back) {
   background: transparent;
   width: 122px;
   height: 59px;
   padding: 32px;
-  background-image: url('/en/latest/_static/logo-docs.svg');
+  background-image: url('logo-docs.svg');
   background-repeat: no-repeat;
   filter: brightness(0) invert(1);
   color: transparent;
@@ -84,10 +74,8 @@ p {
   top: 5px;
   left: 5px;
   font-size: 14px !important;
-  background-image: url('/en/latest/_static/icon-exit.svg') !important;
+  background-image: url('icon-exit.svg') !important;
   background-position: 6px center !important;
-  padding-left: 24px;
-
   background-repeat: no-repeat !important;
   padding-left: 34px !important;
   color: #ccc !important;

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -25,7 +25,7 @@
 
 {% block footer %}
   {{ super() }}
-  <script type="text/javascript" src="/en/latest/_static/js/sticky-sidebar.min.js"></script>
+  <script type="text/javascript" src="_static/js/sticky-sidebar.min.js"></script>
   <script type="text/javascript">
     (function() {
       var stickySidebar = new StickySidebar('.wy-side-scroll');
@@ -37,14 +37,18 @@
   </script>
 
   <script type="text/javascript">
-    fetch('https://api.refine.bio/v1/transcriptome_indices/?limit=1')
-      .then(function(response) {
-        const version = response.headers.get('x-source-revision');
-        const versionElements = document.getElementsByClassName('version');
-        if (versionElements && version) {
-          versionElements[0].textContent = version;
-        }
-      })
+    (function(){
+      const versionElements = document.getElementsByClassName('version');
+      if (versionElements.length === 0) return false;
+      fetch('https://api.refine.bio/v1/transcriptome_indices/?limit=1')
+        .then(function(response) {
+          const version = response.headers.get('x-source-revision');
+          console.log(versionElements)
+          if (versionElements && version) {
+            versionElements[0].textContent = version;
+          }
+        })
+    })()
   </script>
 {% endblock %}
 


### PR DESCRIPTION
Context: https://github.com/AlexsLemonade/refinebio-docs/pull/166#pullrequestreview-1517138998

Previously we were sourcing assets from absolute paths. ie `/latest/en/_static/[file]` to `_static/[file]`
This breaks on preview builds and prevents the site from loading correctly.

This fixes the logo, breadcrumb root, and sticky scroll TOC.

Additionally I added a check to test for the html element to show the version before trying to populate it which errors out when developing locally.

Preview: https://refinebio-docs--167.org.readthedocs.build/en/167/