### PR TITLE
Update documentation to reflect recent harmonization-related changes

### DIFF
--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -47,7 +47,7 @@ Values are stripped of white space and forced to lowercase.
 | Harmonized key | Keys from data sources |
 |:----------------:|-------------------------|
 | `specimen part` | `organism part`, `cell type`, `tissue`, `tissue type`, `tissue source`, `tissue origin`, `source tissue`, `tissue subtype`, `tissue/cell type`, `tissue region`,  `tissue compartment`,  `tissues`, `tissue of origin`, `tissue-type`,  `tissue harvested`, `cell/tissue type`, `tissue subregion`, `organ`, `characteristic [organism part]`, `characteristics [organism part]`, `cell_type`, `organismpart`, `isolation source`, `tissue sampled`, `cell description`
-| `genetic information` | `strain/background`, `strain`,  `strain or line`, `background strain`, `genotype`, `genetic background`, `genotype/variation`, `ecotype`, `cultivar`, `strain/genotype`|
+| `genetic information` | `strain/background`, `strain`,  `strain or line`, `background strain`, `genotype`, `genetic background`, `genotype/variation`, `ecotype`, `cultivar`, `strain/genotype`, `strain background`|
 | `disease` |  `disease `, `disease state `, `disease status `, `diagnosis `, `disease `, `infection with `, `sample type ` |
 | `disease stage` | `disease state `, `disease staging `, `disease stage `, `grade `, `tumor grade `,  `who grade `, `histological grade `, `tumor grading `, `disease outcome `, `subject status ` |
 | `treatment` | `treatment`, `treatment group`, `treatment protocol`,  `drug treatment`, `clinical treatment` |

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -47,7 +47,7 @@ For example, `treatment`, `treatment group`, `treatment protocol`, `drug treatme
 The fields that we currently collapse to includes `specimen part`, `genetic information`, `disease`, `disease stage`, `treatment`, `race`, `subject`, `compound`, `cell_line`, and `time`.
 
 See the table below for the mappings between the keys from source data and the harmonized keys.
-We check a variety of fields from source repositories for the source key values, e.g., the source keys `age`, `characteristic [age]`, and `characteristic_age` would all map to the harmonized key `age`.
+In addition to the source data keys explicitly listed in the table, we check for variants in the metadata from the source repositories, e.g., the source keys `age`, `characteristic [age]`, and `characteristic_age` would all map to the harmonized key `age`.
 
 
 | Harmonized key | Keys from data sources |

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -56,7 +56,7 @@ Values are stripped of white space and forced to lowercase.
 | `compound` | `compound`, `compound1`, `compound2`, `compound name`, `drug`, `drugs`, `immunosuppressive drugs` |
 | `time` | `initial time point`, `start time`, `stop time`, `time point`, `sampling time point`, `sampling time`, `time post infection` |
 | `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years`, `characteristic [age]`, `characteristics [age]` |
-| `cell_line` | `cell line`, `sample strain` |
+| `cell_line` | `cell line` |
 
 We type-cast age values to doubles.
 If the values can not be type-cast to doubles (e.g., "9yrs 2mos"), these are not added to the harmonized field.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -38,7 +38,7 @@ _The `refinebio_processor_version` field in the downloaded metadata file capture
 
 Scientists who upload results don't always use the same names for related values.
 This makes it challenging to search across datasets.
-We have put some processes in place to smooth out some of these issues.
+We have implemented some processes to smooth out some of these issues.
 
 ![harmonized-metadata](https://user-images.githubusercontent.com/15315514/44549202-5eefc800-a6ee-11e8-8a7b-57826f0153f2.png)
 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -63,6 +63,7 @@ In addition to the source data keys explicitly listed in the table, we check for
 | `time` | `time`, `initial time point`, `start time`, `stop time`, `time point`, `sampling time point`, `sampling time`, `time post infection` |
 | `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years` |
 | `cell_line` | `cell line` |
+| `sex` | `sex`, `gender`, `subject gender`, `subject sex` |
 
 Values are stripped of white space and forced to lowercase.
 
@@ -74,13 +75,6 @@ Because of this type-casting behavior, we do not support multiple source keys; t
 If the values can not be type-cast to doubles (e.g., "9yrs 2mos"), these are not added to the harmonized field.
 We do not attempt to normalize differences in units (e.g., months, years, days) for the harmonized age key.
 Users should consult the submitter-supplied information to determine what unit is used.
-
-Sex is a special case; we map to `female` and `male` values if the values are one of the following:
-
-| Harmonized `sex` value | Values |
-|:-----------------------:|-------|
-| `female` | `f`, `female`, `woman`|
-| `male` | `m`, `male`, `man` |
 
 Only harmonized values are displayed in the sample table on the web interface.
 When downloading refine.bio data, these harmonized metadata are denoted with the `refinebio_` prefix.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -31,7 +31,7 @@ Note that we do not yet obtain sample metadata from the <a href = "https://www.n
 ### refine.bio-harmonized Metadata
 
 
-_The documentation in this section reflects data that has been processed via refine.bio as of version TODO: add version._
+_The documentation in this section reflects data that has been processed via refine.bio as of version `v1.45.0`._
 _See the documentation sidebar for the current version of refine.bio._
 _The `refinebio_processor_version` field in the downloaded metadata file captures the refine.bio version when a sample was processed._
 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -36,10 +36,10 @@ We have put some processes in place to smooth out some of these issues.
 
 ![harmonized-metadata](https://user-images.githubusercontent.com/15315514/44549202-5eefc800-a6ee-11e8-8a7b-57826f0153f2.png)
 
-To produce lightly harmonized metadata, we combine certain fields based on similar keys.
+We combine certain fields based on similar keys to produce lightly harmonized metadata.
 We do this for convenience and to aid in searches.
 For example, `treatment`, `treatment group`, `treatment protocol`, `drug treatment`, and `clinical treatment` fields get collapsed down to `treatment`.
-The fields that we currently collapse to includes `specimen part`, `genetic information`, `disease`, `disease stage`, `treatment`, `race`, `subject`, `development stage`, `compound`, `cell_line`, and `time`.
+The fields that we currently collapse to includes `specimen part`, `genetic information`, `disease`, `disease stage`, `treatment`, `race`, `subject`, `compound`, `cell_line`, and `time`.
 
 See the table below for a complete set of mappings between the keys from source data and the harmonized keys.
 Values are stripped of white space and forced to lowercase.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -33,7 +33,7 @@ Note that we do not yet obtain sample metadata from the <a href = "https://www.n
 
 _The documentation in this section reflects data that has been processed via refine.bio as of version TODO: add version._
 _See the documentation sidebar for the current version of refine.bio._
-_The `refinebio_processor_version` field in the metadata captures the refine.bio version when a sample was processed._
+_The `refinebio_processor_version` field in the downloaded metadata file captures the refine.bio version when a sample was processed._
 
 
 Scientists who upload results don't always use the same names for related values.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -58,8 +58,11 @@ Values are stripped of white space and forced to lowercase.
 | `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years`, `characteristic [age]`, `characteristics [age]` |
 | `cell_line` | `cell line` |
 
-We type-cast age values to doubles.
+When multiple source keys that map to the same harmonized key are present in metadata from sources, we concatenate the values, separated by `;`.
+For example, a sample with `cell type: B cell` and `tissue: kidney` would become `specimen_part: B cell;kidney` when harmonized.
+
 We type-cast age values to doubles (e.g., `12` and `12 weeks` both become `12.000`).
+Because of this type-casting behavior, we do not support multiple source keys; the value harmonized to `age` will be the first value that is encountered. 
 If the values can not be type-cast to doubles (e.g., "9yrs 2mos"), these are not added to the harmonized field.
 We do not attempt to normalize differences in units (e.g., months, years, days) for the harmonized age key.
 Users should consult the submitter-supplied information to determine what unit is used.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -46,12 +46,13 @@ To aid in searches and for general convenience, we combine certain fields based 
 For example, `treatment`, `treatment group`, `treatment protocol`, `drug treatment`, and `clinical treatment` fields get collapsed down to `treatment`.
 The fields that we currently collapse to includes `specimen part`, `genetic information`, `disease`, `disease stage`, `treatment`, `race`, `subject`, `compound`, `cell_line`, and `time`.
 
-See the table below for a complete set of mappings between the keys from source data and the harmonized keys.
-Values are stripped of white space and forced to lowercase.
+See the table below for the mappings between the keys from source data and the harmonized keys.
+We check a variety of fields from source repositories for the source key values, e.g., the source keys `age`, `characteristic [age]`, and `characteristic_age` would all map to the harmonized key `age`.
+
 
 | Harmonized key | Keys from data sources |
 |:----------------:|-------------------------|
-| `specimen part` | `organism part`, `cell type`, `tissue`, `tissue type`, `tissue source`, `tissue origin`, `source tissue`, `tissue subtype`, `tissue/cell type`, `tissue region`,  `tissue compartment`,  `tissues`, `tissue of origin`, `tissue-type`,  `tissue harvested`, `cell/tissue type`, `tissue subregion`, `organ`, `characteristic [organism part]`, `characteristics [organism part]`, `cell_type`, `organismpart`, `isolation source`, `tissue sampled`, `cell description`
+| `specimen part` | `organism part`, `cell type`, `tissue`, `tissue type`, `tissue source`, `tissue origin`, `source tissue`, `tissue subtype`, `tissue/cell type`, `tissue region`,  `tissue compartment`,  `tissues`, `tissue of origin`, `tissue-type`,  `tissue harvested`, `cell/tissue type`, `tissue subregion`, `organ`, `cell_type`, `organismpart`, `isolation source`, `tissue sampled`, `cell description`
 | `genetic information` | `strain/background`, `strain`,  `strain or line`, `background strain`, `genotype`, `genetic background`, `genotype/variation`, `ecotype`, `cultivar`, `strain/genotype`, `strain background`|
 | `disease` |  `disease `, `disease state `, `disease status `, `diagnosis `, `disease `, `infection with `, `sample type ` |
 | `disease stage` | `disease state `, `disease staging `, `disease stage `, `grade `, `tumor grade `,  `who grade `, `histological grade `, `tumor grading `, `disease outcome `, `subject status ` |
@@ -60,8 +61,10 @@ Values are stripped of white space and forced to lowercase.
 | `subject` |  `subject `, `subject id `, `subject/sample source id `, `subject identifier `, `human subject anonymized id `, `individual `, `individual identifier `,  `individual id `, `patient `, `patient id `, `patient identifier `,  `patient number `, `patient no `,  `donor id `, `donor `, `sample_source_name `|
 | `compound` | `compound`, `compound1`, `compound2`, `compound name`, `drug`, `drugs`, `immunosuppressive drugs` |
 | `time` | `time`, `initial time point`, `start time`, `stop time`, `time point`, `sampling time point`, `sampling time`, `time post infection` |
-| `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years`, `characteristic [age]`, `characteristics [age]` |
+| `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years` |
 | `cell_line` | `cell line` |
+
+Values are stripped of white space and forced to lowercase.
 
 When multiple source keys that map to the same harmonized key are present in metadata from sources, we concatenate the values, separated by `;`.
 For example, a sample with `cell type: B cell` and `tissue: kidney` would become `specimen_part: B cell;kidney` when harmonized.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -42,8 +42,7 @@ We have put some processes in place to smooth out some of these issues.
 
 ![harmonized-metadata](https://user-images.githubusercontent.com/15315514/44549202-5eefc800-a6ee-11e8-8a7b-57826f0153f2.png)
 
-We combine certain fields based on similar keys to produce lightly harmonized metadata.
-We do this for convenience and to aid in searches.
+To aid in searches and for general convenience, we combine certain fields based on similar keys to produce lightly harmonized metadata.
 For example, `treatment`, `treatment group`, `treatment protocol`, `drug treatment`, and `clinical treatment` fields get collapsed down to `treatment`.
 The fields that we currently collapse to includes `specimen part`, `genetic information`, `disease`, `disease stage`, `treatment`, `race`, `subject`, `compound`, `cell_line`, and `time`.
 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -59,7 +59,7 @@ Values are stripped of white space and forced to lowercase.
 | `race` | `race`, `ethnicity`, `race/ethnicity`|
 | `subject` |  `subject `, `subject id `, `subject/sample source id `, `subject identifier `, `human subject anonymized id `, `individual `, `individual identifier `,  `individual id `, `patient `, `patient id `, `patient identifier `,  `patient number `, `patient no `,  `donor id `, `donor `, `sample_source_name `|
 | `compound` | `compound`, `compound1`, `compound2`, `compound name`, `drug`, `drugs`, `immunosuppressive drugs` |
-| `time` | `initial time point`, `start time`, `stop time`, `time point`, `sampling time point`, `sampling time`, `time post infection` |
+| `time` | `time`, `initial time point`, `start time`, `stop time`, `time point`, `sampling time point`, `sampling time`, `time post infection` |
 | `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years`, `characteristic [age]`, `characteristics [age]` |
 | `cell_line` | `cell line` |
 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -66,8 +66,8 @@ We check a variety of fields from source repositories for the source key values,
 
 Values are stripped of white space and forced to lowercase.
 
-When multiple source keys that map to the same harmonized key are present in metadata from sources, we concatenate the values, separated by `;`.
-For example, a sample with `cell type: B cell` and `tissue: kidney` would become `specimen_part: B cell;kidney` when harmonized.
+When multiple source keys that map to the same harmonized key are present in metadata from sources, we sort values in alphanumeric ascending order and concatenate them, separated by `;`.
+For example, a sample with `tissue: kidney` and `cell type: B cell` would become `specimen_part: B cell;kidney` when harmonized.
 
 We type-cast age values to doubles (e.g., `12` and `12 weeks` both become `12.000`).
 Because of this type-casting behavior, we do not support multiple source keys; the value harmonized to `age` will be the first value that is encountered. 

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -63,7 +63,6 @@ In addition to the source data keys explicitly listed in the table, we check for
 | `time` | `time`, `initial time point`, `start time`, `stop time`, `time point`, `sampling time point`, `sampling time`, `time post infection` |
 | `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years` |
 | `cell_line` | `cell line` |
-| `sex` | `sex`, `gender`, `subject gender`, `subject sex` |
 
 Values are stripped of white space and forced to lowercase.
 
@@ -75,6 +74,13 @@ Because of this type-casting behavior, we do not support multiple source keys; t
 If the values can not be type-cast to doubles (e.g., "9yrs 2mos"), these are not added to the harmonized field.
 We do not attempt to normalize differences in units (e.g., months, years, days) for the harmonized age key.
 Users should consult the submitter-supplied information to determine what unit is used.
+
+Sex is a special case; we map to `female` and `male` values if the values are one of the following:
+
+| Harmonized `sex` value | Values |
+|:-----------------------:|-------|
+| `female` | `f`, `female`, `woman`|
+| `male` | `m`, `male`, `man` |
 
 Only harmonized values are displayed in the sample table on the web interface.
 When downloading refine.bio data, these harmonized metadata are denoted with the `refinebio_` prefix.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -30,6 +30,12 @@ Note that we do not yet obtain sample metadata from the <a href = "https://www.n
 
 ### refine.bio-harmonized Metadata
 
+
+_The documentation in this section reflects data that has been processed via refine.bio as of version TODO: add version._
+_See the documentation sidebar for the current version of refine.bio._
+_The `refinebio_processor_version` field in the metadata captures the refine.bio version when a sample was processed._
+
+
 Scientists who upload results don't always use the same names for related values.
 This makes it challenging to search across datasets.
 We have put some processes in place to smooth out some of these issues.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -59,6 +59,7 @@ Values are stripped of white space and forced to lowercase.
 | `cell_line` | `cell line` |
 
 We type-cast age values to doubles.
+We type-cast age values to doubles (e.g., `12` and `12 weeks` both become `12.000`).
 If the values can not be type-cast to doubles (e.g., "9yrs 2mos"), these are not added to the harmonized field.
 We do not attempt to normalize differences in units (e.g., months, years, days) for the harmonized age key.
 Users should consult the submitter-supplied information to determine what unit is used.

--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -63,6 +63,7 @@ In addition to the source data keys explicitly listed in the table, we check for
 | `time` | `time`, `initial time point`, `start time`, `stop time`, `time point`, `sampling time point`, `sampling time`, `time post infection` |
 | `age` | `age`, `patient age`, `age of patient`, `age (years)`, `age at diagnosis`, `age at diagnosis years` |
 | `cell_line` | `cell line` |
+| `sex` | `sex`, `gender`, `subject gender`, `subject sex` |
 
 Values are stripped of white space and forced to lowercase.
 


### PR DESCRIPTION
_⚠️  This is stacked on #171, so I could build locally._

#### Purpose

This pull request makes the following changes that reflect impending changes to how metadata are harmonized:

* Adds `strain background` to the source keys that are harmonized to `genetic_information`
* Removes `sample strain` from the source keys harmonized to `cell line`.
* Adds information about new behavior when multiple source keys map to the same harmonized key (closes #160).
* Adds an example clarifying how age type-casting behavior works (closes #164) and notes that age is a special case for multiple source keys.
* Adds a note about when these changes will be effective. This currently has a TODO with version information (cc: @davidsmejia). Our docs are written in Markdown, and unfortunately, Sphinx only supports notes and warnings in reStructured Text, as far as I can tell.

#### Reviewer instructions

* @davidsmejia 
  * What version should replace the TODO?
  * Please check that I've captured all the recent changes accurately.
  * I suspect that `refinebio_processor_version` only captures processors and not surveyors. So presumably, one could have versions of refine.bio in your downloaded metadata that don't reflect when harmonization happened. Is this right? (If it is right, still might not happen much in practice 🤔 ).
* @dvenprasad 
  * Please see what you think of the note I've added under "refine.bio Harmonized Metadata." It would be better if we could use notes (see **Purpose**), but such is life!
  * FYI - about decoupling the processor version from the harmonization version noted above (we'll see what David says). 
* @jashapiro, please review for clarity.