### PR TITLE
Port over initial spell check configuration from r.bio admin set up

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,21 @@
+name: Spellcheck Markdown Files
+
+on: 
+    pull_request:
+        branches:
+            - development
+    workflow_dispatch:  #for testing
+
+jobs:
+  build:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+    # The checkout step
+    - uses: actions/checkout@v3
+    - uses: rojopolis/spellcheck-github-actions@0.30.0
+      name: Spellcheck
+      with:
+        config_path: config/.spellcheck-config.yml
+        source_files: '**/*.md'
+        task_name: Markdown

--- a/config/.spellcheck-config.yml
+++ b/config/.spellcheck-config.yml
@@ -1,0 +1,19 @@
+matrix:
+- name: Markdown
+  aspell:
+    lang: en
+    ignore-case: true
+  dictionary:
+    wordlists:
+    - config/.custom-dictionary.txt
+    encoding: utf-8
+  pipeline:
+  - pyspelling.filters.markdown:
+  - pyspelling.filters.html:
+      comments: false
+      ignores:
+      - code
+      - pre
+  sources:
+  - '**/*.md'
+  default_encoding: utf-8


### PR DESCRIPTION
Partially addresses #147. Once this goes in, I'll use the `workflow_dispatch` trigger to start populating the custom dictionary, which is currently blank. One difference from the refine.bio admin set up is that the default branch is development.