### PR TITLE
Add header and intro paragraph for Childhood Cancer Collections

### DIFF
--- a/docs/main_text.md
+++ b/docs/main_text.md
@@ -558,6 +558,16 @@ Below is the detailed folder structure:
 
 ![docs-downloads-quantpendia](https://user-images.githubusercontent.com/15315514/65271488-4289af00-daeb-11e9-9006-2d7536c4a103.png)
 
+# Childhood Cancer Collections
+
+Childhood Cancer Collections (CCC) are curated collections of pediatric cancer research relevant datasets available from refine.bio.
+Childhood Cancer Data Data Lab staff members select the dataset in CCC based on criteria such as the information contained in a submitter-supplied abstract, age ranges associated with samples in an experiment, and tagged ontology terms.
+We are pleased to offer improved searching and filtering functionality in the CCC to make it easier for pediatric cancer researchers to discover and use data from refine.bio, as detailed below.
+
+<!--
+## Finding Samples and Experiments
+-->
+
 # API
 
 You can use the refine.bio API to build your own applications utilizing the refine.bio processed data.


### PR DESCRIPTION
Closes #174 

Here, I'm adding the introductory paragraph for Childhood Cancer Collections. I've inserted this in the `main_text.md` document based on my understanding of the [requirements/IA doc](https://data-lab-knowledge.slab.com/posts/2023-05-09-ccc-docs-changes-and-ia-dvltb6l9).

I also stubbed in the only header I expect under CCC – Finding Samples and Experiments; it is currently within an HTML comment. Again, this is based on my understanding of the requirements/IA doc.

Some notes for reviewers on my language choices:

* Tagged terms will already be introduced in a section after processing information.
* "Submitter-supplied" is a bit of terminology we use throughout the docs to describe the information we get from ArrayExpress, SRA, and GEO.

In the future, I expect I will modify this paragraph to link to other sections (e.g., tagged terms, FAQ) as appropriate.