### PR TITLE
Fix `organism__name` filter in documentation on downloading transcriptome indices

### DIFF
--- a/docs/_main/2_processing_information.md
+++ b/docs/_main/2_processing_information.md
@@ -92,14 +92,14 @@ The refine.bio processed Salmon indices are available for download.
 You can make use of our API like so:
 
 ```
-https://api.refine.bio/v1/transcriptome_indices/?organism_name=<ORGANISM>&length=<LENGTH>
+https://api.refine.bio/v1/transcriptome_indices/?organism__name=<ORGANISM>&length=<LENGTH>
 ```
 Where `<ORGANISM>` is the scientific name of the species in all caps separated by underscores and `<LENGTH>` is either `SHORT` or `LONG`.
 
 To obtain the zebrafish (_Danio rerio_) index used for >75bp reads, use:
 
 ```
-https://api.refine.bio/v1/transcriptome_indices/?organism_name=DANIO_RERIO&length=LONG
+https://api.refine.bio/v1/transcriptome_indices/?organism__name=DANIO_RERIO&length=LONG
 ```
 
 The `download_url` field will allow you to download the index.


### PR DESCRIPTION
⚠️  _stacked on #188_ 

Closes #186. Changes to the API mean we need to use `organism__name` instead of `organism_name` in these instructions.